### PR TITLE
Simplify Riemann connectivity even more

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.13
+sbt.version = 0.13.17

--- a/src/main/scala/io/iohk/ethereum/utils/Riemann.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Riemann.scala
@@ -2,49 +2,43 @@ package io.iohk.ethereum.utils
 
 import java.io.{IOException, PrintWriter}
 import java.net.InetAddress
-import java.util.LinkedList
-import java.util.concurrent._
+import java.util.concurrent.TimeUnit
 
-import com.googlecode.protobuf.format.FormatFactory
 import io.iohk.ethereum.buildinfo.MantisBuildInfo
 import io.iohk.ethereum.utils.events.{EventState, EventTag}
-import io.riemann.riemann.Proto.{Event, Msg}
 import io.riemann.riemann.client._
 import org.apache.commons.io.output.StringBuilderWriter
 
-import scala.collection.JavaConverters._
-
 trait Riemann extends Logger {
-
   private val hostName = Config.riemann
     .map(_.hostName)
     .getOrElse(InetAddress.getLocalHost().getHostName())
 
   private val riemannClient: IRiemannClient = {
-    log.debug("create new RiemannClient")
+    // fallback
+    val stdoutClient = new RiemannStdoutClient()
 
-    val stdoutClient: IRiemannClient = {
-      log.info("create new stdout riemann client")
-      val client = new RiemannStdoutClient()
-      client.connect()
-      client
-    }
+    Config.riemann match {
+      case Some(config) =>
+        val transport = new TcpTransport(config.host, config.port)
+        transport.setWriteBufferLimit(config.bufferSize)
+        val client = new RiemannClient(transport)
+        val batchClient = new RiemannBatchClient(config, client, stdoutClient)
 
-    val c = {
-      Config.riemann match {
-        case Some(config) => {
-          log.info(s"create new riemann batch client connecting to ${config.host}:${config.port}")
-          val client = new RiemannBatchClient(config, stdoutClient)
-          client.run()
-          client
+        try {
+          batchClient.connect()
+          log.info(s"Connected to $batchClient")
+          batchClient
         }
-        case None => {
-          stdoutClient
+        catch {
+          case e: IOException =>
+            log.warn(s"Could not connect to $batchClient. Will fallback to $stdoutClient and try to reconnect later")
+            batchClient
         }
-      }
-    }
 
-    c
+      case None =>
+        stdoutClient
+    }
   }
 
   def hostForEvents: String = hostName
@@ -96,212 +90,6 @@ trait Riemann extends Logger {
 }
 
 object Riemann extends Riemann
-
-class RiemannBatchClient(config: RiemannConfiguration, fallbackClient: IRiemannClient) extends IRiemannClient with Logger {
-  private def promise[A](v: A): Promise[A] = {
-    val p: Promise[A] = new Promise()
-    p.deliver(v)
-    p
-  }
-
-  private def simpleMsg(event: Event) = {
-    val msg = Msg.newBuilder().addEvents(event).build()
-    promise(msg)
-  }
-
-  protected val queue: BlockingQueue[Event] = new ArrayBlockingQueue(config.bufferSize)
-
-  private val client = RiemannClient.tcp(config.host, config.port)
-
-  private val executor: ScheduledExecutorService = Executors.newScheduledThreadPool(1)
-
-  protected def sendBatch(): Unit = {
-    val batch: LinkedList[Event] = new LinkedList()
-    queue.drainTo(batch, config.batchSize)
-    batch.add(Riemann.ok("riemann batch").metric(batch.size()).build())
-    batch.add(Riemann.ok("riemann buffer").metric(queue.size()).build())
-    try {
-      log.trace("try to send batch")
-      val p = client.sendEvents(batch)
-      client.flush()
-      val result = p.deref()
-      log.trace(s"sent batch with result: $result")
-    } catch {
-      case e: Throwable =>
-        log.error(s"Error during sending events to Riemann: ${e.toString}")
-        fallbackClient.sendEvents(batch)
-    }
-  }
-
-  private val sender: Runnable = () => {
-    log.trace("run sender")
-    while (queue.size() > 0) {
-      log.trace("sending batch of Riemann events")
-      sendBatch()
-      log.trace("sent batch of Riemann events")
-    }
-  }
-
-  private def scheduleSender() = {
-    executor.scheduleAtFixedRate(sender, config.autoFlushMilliseconds, config.autoFlushMilliseconds, TimeUnit.MILLISECONDS)
-  }
-
-  override def sendEvent(event: Event): Promise[Msg] = {
-    val res = queue.offer(event)
-    if (!res) {
-      log.error("Riemann buffer full")
-      fallbackClient.sendEvent(event)
-    }
-    simpleMsg(event)
-  }
-
-  override def sendMessage(msg: Msg): IPromise[Msg] = client.sendMessage(msg)
-
-  override def event(): EventDSL = {
-    new EventDSL(this)
-  }
-
-  override def query(q: String): IPromise[java.util.List[Event]] =
-    client.query(q)
-
-  override def sendEvents(events: java.util.List[Event]): IPromise[Msg] = {
-    val p = new ChainPromise[Msg]
-    events.asScala.foreach { e =>
-      val clientPromise = sendEvent(e)
-      p.attach(clientPromise)
-    }
-    p
-  }
-
-  override def sendEvents(events: Event*): IPromise[Msg] = {
-    val p = new ChainPromise[Msg]
-    events.foreach { e =>
-      val clientPromise = sendEvent(e)
-      p.attach(clientPromise)
-    }
-    p
-  }
-
-  override def sendException(service: String, t: Throwable): IPromise[Msg] =
-    client.sendException(service, t)
-
-  override def connect(): Unit = {
-    try {
-      client.connect()
-      log.info("connected successfully to riemann server")
-    } catch {
-      case _: IOException =>
-        log.error("unable to connect to Riemann, it will try to connect later")
-    }
-  }
-
-  def run(): Unit = {
-    connect()
-    scheduleSender()
-  }
-
-  override def close(): Unit = {
-    executor.shutdown()
-    flush()
-    client.close()
-  }
-
-  override def flush(): Unit = client.flush()
-
-  override def isConnected(): Boolean = client.isConnected
-
-  override def reconnect(): Unit = {
-    try {
-      client.reconnect()
-      log.info("reconnected successfully to riemann server")
-    } catch {
-      case _: IOException =>
-        log.error("unable to reconnect to Riemann")
-    }
-  }
-
-  override def transport(): Transport = this
-}
-
-class RiemannStdoutClient extends IRiemannClient {
-  private var connected = false
-
-  private def promise[A](v: A): Promise[A] = {
-    val p: Promise[A] = new Promise()
-    p.deliver(v)
-    p
-  }
-
-  private def simpleMsg(event: Event) = {
-    val msg = Msg.newBuilder().addEvents(event).build()
-    promise(msg)
-  }
-
-  private val jsonFormatter = new FormatFactory().createFormatter(FormatFactory.Formatter.JSON)
-
-  override def connect(): Unit = {
-    connected = true
-  }
-
-  override def sendEvent(event: Event): Promise[Msg] = {
-    // scalastyle:off
-    println(jsonFormatter.printToString(event))
-    simpleMsg(event)
-  }
-
-  override def sendMessage(msg: Msg): IPromise[Msg] = {
-    // scalastyle:off
-    println(jsonFormatter.printToString(msg))
-    promise(msg)
-  }
-
-  override def event(): EventDSL = {
-    new EventDSL(this)
-  }
-
-  override def query(q: String): IPromise[java.util.List[Event]] = {
-    promise(new java.util.LinkedList())
-  }
-
-  override def sendEvents(events: java.util.List[Event]): IPromise[Msg] = {
-    events.asScala.foreach { e =>
-      // scalastyle:off
-      println(jsonFormatter.printToString(e))
-    }
-    val msg = Msg.newBuilder().build()
-    promise(msg)
-  }
-
-  override def sendEvents(events: Event*): IPromise[Msg] = {
-    events.foreach { e =>
-      // scalastyle:off
-      println(jsonFormatter.printToString(e))
-    }
-    val msg = Msg.newBuilder().build()
-    promise(msg)
-  }
-
-  override def sendException(service: String, t: Throwable): IPromise[Msg] = {
-    // scalastyle:off
-    System.err.println(s"service: ${service}\n${t}")
-    val msg = Msg.newBuilder().build()
-    promise(msg)
-  }
-  override def close(): Unit = {
-    connected = false
-  }
-
-  override def flush(): Unit = {}
-
-  override def isConnected(): Boolean = connected
-
-  override def reconnect(): Unit = {
-    connected = true
-  }
-
-  override def transport(): Transport = this
-
-}
 
 trait ToRiemann {
   def toRiemann: EventDSL

--- a/src/main/scala/io/iohk/ethereum/utils/RiemannBatchClient.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/RiemannBatchClient.scala
@@ -1,0 +1,146 @@
+package io.iohk.ethereum.utils
+
+import java.io.IOException
+import java.util
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+import java.util.concurrent.{LinkedTransferQueue, TimeUnit}
+
+import io.riemann.riemann.Proto
+import io.riemann.riemann.Proto.Event
+import io.riemann.riemann.client._
+
+import scala.collection.JavaConverters._
+
+
+class RiemannBatchClient(
+  config: RiemannConfiguration,
+  client: RiemannClient,
+  fallback: RiemannStdoutClient
+) extends IRiemannClient with Logger {
+
+  private val batchSize = config.batchSize
+  private val autoFlushMs = config.autoFlushMilliseconds
+  private val alreadyCalledConnect = new AtomicBoolean(false)
+  private val lastIsConnectedRef = new AtomicReference[Option[Boolean]](None)
+  private val schedulerRef = new AtomicReference[Option[RiemannScheduler]](None)
+
+  private val queue = new LinkedTransferQueue[Event]()
+
+  private val offerSuccessMsg = Proto.Msg.newBuilder().setOk(true).build()
+  private val offerSuccessPromise: IPromise[Proto.Msg] = {
+    val p = new Promise[Proto.Msg]()
+    p.deliver(offerSuccessMsg)
+    p
+  }
+
+  private def offer(event: Event): IPromise[Proto.Msg] = {
+    queue.offer(event)
+    offerSuccessPromise
+  }
+
+  private def checkConnected(): Boolean = {
+    val isConnected = client.isConnected
+    val lastIsConnectedOpt = this.lastIsConnectedRef.get()
+
+    (lastIsConnectedOpt, isConnected) match {
+      case (Some(true), false) =>
+        log.warn(s"Disconnected from ${this}")
+      case (Some(false), true) =>
+        log.info(s"Reconnected to ${this}")
+      case _ =>
+        // no interesting state transition
+    }
+
+    this.lastIsConnectedRef.set(Some(isConnected))
+
+    isConnected
+  }
+
+  private def drain(): Unit = {
+    val batch = new util.ArrayList[Event](batchSize)
+    queue.drainTo(batch, batchSize)
+
+    def sendToFallback(): Unit = {
+      for(event ← batch.asScala) {
+        fallback.sendEvent(event)
+      }
+    }
+
+    def sendToClient(): Unit = {
+      try {
+        val msg = Proto.Msg.newBuilder().addAllEvents(batch).build()
+        client.sendMessage(msg)
+        client.flush()
+      }
+      catch {
+        case e: IOException =>
+          log.warn(s"Could not send a batch of ${batch.size()} to $this. Falling back to $fallback")
+          sendToFallback()
+      }
+    }
+
+
+    if(checkConnected())
+      sendToClient()
+    else
+      sendToFallback()
+  }
+
+  // Actually sends the message over the wire directly, instead of using the queue.
+  def sendMessage(msg: Proto.Msg): IPromise[Proto.Msg] =
+    client.sendMessage(msg)
+
+  // Actually sends the exception over the wire directly, instead of using the queue.
+  def sendException(service: String, t: Throwable): IPromise[Proto.Msg] =
+    client.sendException(service, t)
+
+  def query(q: String): IPromise[util.List[Proto.Event]] =
+    client.query(q)
+
+  def sendEvent(event: Proto.Event): IPromise[Proto.Msg] =
+    offer(event)
+
+  def sendEvents(events: Proto.Event*): IPromise[Proto.Msg] = {
+    for(event ← events) { offer(event) }
+    offerSuccessPromise
+  }
+
+  def sendEvents(events: util.List[Proto.Event]): IPromise[Proto.Msg] =
+    sendEvents(events.asScala:_*)
+
+
+  def event(): EventDSL = new EventDSL(this)
+
+  def isConnected: Boolean = client.isConnected
+
+  def connect(): Unit = {
+    try client.connect()
+    finally {
+      if(alreadyCalledConnect.compareAndSet(false, true)) {
+        // Setup the scheduler that periodically sends events to Riemann
+        val scheduler = client.scheduler()
+        schedulerRef.set(Some(scheduler))
+
+        scheduler.every(autoFlushMs, TimeUnit.MILLISECONDS, () ⇒ drain())
+      }
+    }
+  }
+
+  def reconnect(): Unit = {
+    close()
+    connect()
+  }
+
+  def flush(): Unit = client.flush()
+
+  def close(): Unit = {
+    fallback.close()
+    client.close()
+    schedulerRef.get().foreach(_.shutdown())
+    // and now the client becomes unusable.
+  }
+
+  def transport(): Transport = client.transport()
+
+  override def toString: String = s"Riemann(${config.host}:${config.port})"
+}

--- a/src/main/scala/io/iohk/ethereum/utils/RiemannStdoutClient.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/RiemannStdoutClient.scala
@@ -1,0 +1,89 @@
+package io.iohk.ethereum.utils
+
+import com.googlecode.protobuf.format.FormatFactory
+import io.riemann.riemann.Proto.{Event, Msg}
+import io.riemann.riemann.client._
+
+import scala.collection.JavaConverters._
+
+
+class RiemannStdoutClient extends IRiemannClient {
+  private var connected = false
+
+  private def promise[A](v: A): Promise[A] = {
+    val p: Promise[A] = new Promise()
+    p.deliver(v)
+    p
+  }
+
+  private def simpleMsg(event: Event) = {
+    val msg = Msg.newBuilder().addEvents(event).build()
+    promise(msg)
+  }
+
+  private val jsonFormatter = new FormatFactory().createFormatter(FormatFactory.Formatter.JSON)
+
+  override def connect(): Unit = {
+    connected = true
+  }
+
+  override def sendEvent(event: Event): Promise[Msg] = {
+    // scalastyle:off
+    println(jsonFormatter.printToString(event))
+    simpleMsg(event)
+  }
+
+  override def sendMessage(msg: Msg): IPromise[Msg] = {
+    // scalastyle:off
+    println(jsonFormatter.printToString(msg))
+    promise(msg)
+  }
+
+  override def event(): EventDSL = {
+    new EventDSL(this)
+  }
+
+  override def query(q: String): IPromise[java.util.List[Event]] = {
+    promise(new java.util.LinkedList())
+  }
+
+  override def sendEvents(events: java.util.List[Event]): IPromise[Msg] = {
+    events.asScala.foreach { e =>
+      // scalastyle:off
+      println(jsonFormatter.printToString(e))
+    }
+    val msg = Msg.newBuilder().build()
+    promise(msg)
+  }
+
+  override def sendEvents(events: Event*): IPromise[Msg] = {
+    events.foreach { e =>
+      // scalastyle:off
+      println(jsonFormatter.printToString(e))
+    }
+    val msg = Msg.newBuilder().build()
+    promise(msg)
+  }
+
+  override def sendException(service: String, t: Throwable): IPromise[Msg] = {
+    // scalastyle:off
+    System.err.println(s"service: ${service}\n${t}")
+    val msg = Msg.newBuilder().build()
+    promise(msg)
+  }
+  override def close(): Unit = {
+    connected = false
+  }
+
+  override def flush(): Unit = {}
+
+  override def isConnected(): Boolean = connected
+
+  override def reconnect(): Unit = {
+    connected = true
+  }
+
+  override def transport(): Transport = this
+
+  override def toString: String = getClass.getSimpleName
+}


### PR DESCRIPTION
* Reuse infra provided by the Riemann lib
* Properly log (re)connection/disconnection status
* Also, refactor and move some classes to their own files

Ref GMC-58