### PR TITLE
Removing some hardcoded references to /tmp in the test suite.

### DIFF
--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -2,7 +2,7 @@ mantis {
 
   client-id = "mantis"
 
-  datadir = "/tmp/mantis-test/"
+  datadir = ${java.io.tmpdir}"/mantis-test/"
 
   secure-random-algo = "NativePRNGNonBlocking"
 

--- a/src/test/scala/io/iohk/ethereum/db/dataSource/LevelDBDataSourceTest.scala
+++ b/src/test/scala/io/iohk/ethereum/db/dataSource/LevelDBDataSourceTest.scala
@@ -8,7 +8,7 @@ class LevelDBDataSourceTest extends FlatSpec with DataSourceTestBehavior {
     override val verifyChecksums: Boolean = true
     override val paranoidChecks: Boolean = true
     override val createIfMissing: Boolean = true
-    override val path: String = "/tmp/test/leveldb/"
+    override val path: String = System.getProperty("java.io.tmpdir") + "/test/leveldb/"
   })
 
   it should behave like dataSource(createDataSource)


### PR DESCRIPTION
This breaks nix builds, which isolate their own temp directory.